### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "BSD-3-Clause"
 homepage = "https://github.com/ollien/quicknotes"
 repository = "https://github.com/ollien/quicknotes"
 edition = "2021"
-rust-version = "1.82"
+rust-version = "1.83"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "BSD-3-Clause"
 homepage = "https://github.com/ollien/quicknotes"
 repository = "https://github.com/ollien/quicknotes"
 edition = "2021"
+rust-version = "1.82"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Hi, thanks for building this - it looks useful so I thought I'd give it a try. I was on a slightly older version of rust on some machines, and got an error whilst building. 

io_error_more seems to have been stabalised in 1.82. (https://github.com/rust-lang/rust/issues/131396)

Compiling with 1.80 I get:

```
error[E0658]: use of unstable library feature 'io_error_more'
   --> C:\Users\paul\.cargo\registry\src\index.crates.io-6f17d22bba15001f\quicknotes-1.0.1\src/lib.rs:412:17
    |
412 |                 io::ErrorKind::IsADirectory,
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #86442 <https://github.com/rust-lang/rust/issues/86442> for more information
```